### PR TITLE
install ca-certificates into container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV LANG en_US.UTF-8
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys DE742AFA && \
     echo "deb http://ppa.launchpad.net/maxmind/ppa/ubuntu xenial main" > /etc/apt/sources.list.d/maxmind.list && \
     apt-get update && \
-    apt-get install --no-install-recommends -y geoipupdate && \
+    apt-get install --no-install-recommends -y geoipupdate ca-certificates && \
     apt-get -qy autoremove && \
     apt-get clean && \
     rm -r /var/lib/apt/lists/*


### PR DESCRIPTION
Looks like `ca-certificates` package was removed from `ubuntu:16.04` image we are base on.